### PR TITLE
Defer icon loading

### DIFF
--- a/src/GithubOcticonsServiceProvider.php
+++ b/src/GithubOcticonsServiceProvider.php
@@ -14,10 +14,12 @@ class GithubOcticonsServiceProvider extends ServiceProvider
 {
     public function boot(): void
     {
-        $this->app->make(Factory::class)->add('github-octicons', [
-            'path' => __DIR__ . '/../resources/svg',
-            'prefix' => 'go',
-        ]);
+        $this->callAfterResolving(Factory::class, function (Factory $factory) {
+            $factory->add('github-octicons', [
+                'path' => __DIR__ . '/../resources/svg',
+                'prefix' => 'go',
+            ]);
+        });
 
         if ($this->app->runningInConsole()) {
             $this->publishes([


### PR DESCRIPTION
These changes will defer the icon loading until the factory has actually been resolved. This is also the new recommended way for packages to integrate with Blade Icons. No breaking changes, the previous way will still work.