### PR TITLE
Update to Blade Icons 0.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
   "description":"A package to easily make use of Github octicons in your Laravel blade views.",
   "license": "MIT",
   "require": {
-    "php": "^7.2",
-    "blade-ui-kit/blade-icons": "^0.4.5",
+    "php": "^7.3",
+    "blade-ui-kit/blade-icons": "^0.5",
     "illuminate/support": "^7.14|^8.0"
   },
   "require-dev": {


### PR DESCRIPTION
This will update the library to the latest Blade Icons version. I've removed these icons from the Blade UI Kit website repo for now because this is blocking its upgrade to Laravel 8. Feel free to let me know when this change has been tagged and I'll re-add it.